### PR TITLE
Stream Deserialize

### DIFF
--- a/CaptainPav.WebApiProxy/CaptainPav.WebApiProxy.csproj
+++ b/CaptainPav.WebApiProxy/CaptainPav.WebApiProxy.csproj
@@ -12,6 +12,7 @@
     <Authors>Michael Pavlak</Authors>
     <Product>WebApiProxy</Product>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CaptainPav.WebApiProxy/DefaultHttpResponseMessageReader.cs
+++ b/CaptainPav.WebApiProxy/DefaultHttpResponseMessageReader.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -31,6 +32,42 @@ namespace CaptainPav.WebApiProxy
 			return ReadMessageIfSuccessfulOrThrowAsync(message, this.ExceptionReconstructor, validCodes);
 		}
 
+		public Task<Stream> GetStreamIfSuccessfulOrThrowAsync(HttpResponseMessage message, params HttpStatusCode[] validCodes)
+		{
+			return GetStreamIfSuccessfulOrThrowAsync(message, this.ExceptionReconstructor, validCodes);
+		}
+
+		public Task ThrowIfNotSuccessfulAsync(HttpResponseMessage message, params HttpStatusCode[] validCodes)
+		{
+			return ThrowIfNotSuccessfulAsync(message, this.ExceptionReconstructor, validCodes);
+		}
+
+		/// <summary>
+		/// Throws an exception if the response message indicates
+		/// an unsuccessful result
+		/// </summary>
+		/// <param name="message">
+		/// The <see cref="HttpResponseMessage"/> to check for failure
+		/// </param>
+		/// <param name="reconstructor">
+		/// When the <see cref="HttpResponseMessage"/> indicates an unsuccessful
+		/// response, then this reconstructor is used to try and reconstruct the
+		/// original exception.
+		/// </param>
+		/// <param name="validCodes">
+		/// The set of <see cref="HttpStatusCode"/>s which represent a successful call
+		/// </param>
+		/// <exception cref="UnexpectedStatusCodeException">
+		/// Thrown if the <see cref="HttpResponseMessage"/> indicates an unsuccessful status code
+		/// </exception>
+		public static async Task ThrowIfNotSuccessfulAsync(HttpResponseMessage message, IExceptionReconstructor reconstructor, params HttpStatusCode[] validCodes)
+		{
+			if (!message.IsResponseSuccessful(validCodes))
+			{
+				throw message.CreateExceptionIfNotSuccessful(await reconstructor.Reconstruct(message).ConfigureAwait(false), validCodes);
+			}
+		}
+
 		/// <summary>
 		/// Attempts to read the <see cref="HttpResponseMessage"/> body as a
 		/// string and throws an exception if the response message indicates
@@ -40,7 +77,7 @@ namespace CaptainPav.WebApiProxy
 		/// The <see cref="HttpResponseMessage"/> to read
 		/// </param>
 		/// <param name="reconstructor">
-		///  When the <see cref="HttpResponseMessage"/> indicates an unsuccessful
+		/// When the <see cref="HttpResponseMessage"/> indicates an unsuccessful
 		/// response, then this reconstructor is used to try and reconstruct the
 		/// original exception.
 		/// </param>
@@ -52,16 +89,43 @@ namespace CaptainPav.WebApiProxy
 		/// otherwise, an exception is thrown.
 		/// </returns>
 		/// <exception cref="UnexpectedStatusCodeException">
-		/// Throw if the <see cref="HttpResponseMessage"/> indicates an unsuccessful status code
+		/// Thrown if the <see cref="HttpResponseMessage"/> indicates an unsuccessful status code
 		/// </exception>
 		public static async Task<string> ReadMessageIfSuccessfulOrThrowAsync(HttpResponseMessage message, IExceptionReconstructor reconstructor, params HttpStatusCode[] validCodes)
 		{
-			if (!message.IsResponseSuccessful(validCodes))
-			{
-				throw message.CreateExceptionIfNotSuccessful(await reconstructor.Reconstruct(message).ConfigureAwait(false), validCodes);
-			}
+			await ThrowIfNotSuccessfulAsync(message, reconstructor, validCodes).ConfigureAwait(false);
 
 			return await message.Content.ReadAsStringAsync().ConfigureAwait(false);
+		}
+
+		/// <summary>
+		/// Attempts to read the <see cref="HttpResponseMessage"/> body stream
+		/// and throws an exception if the response message indicates
+		/// an unsuccessful result
+		/// </summary>
+		/// <param name="message">
+		/// The <see cref="HttpResponseMessage"/> to read
+		/// </param>
+		/// <param name="reconstructor">
+		/// When the <see cref="HttpResponseMessage"/> indicates an unsuccessful
+		/// response, then this reconstructor is used to try and reconstruct the
+		/// original exception.
+		/// </param>
+		/// <param name="validCodes">
+		/// The set of <see cref="HttpStatusCode"/>s which represent a successful call
+		/// </param>
+		/// <returns>
+		/// The content body stream if the request indicates success;
+		/// otherwise, an exception is thrown.
+		/// </returns>
+		/// <exception cref="UnexpectedStatusCodeException">
+		/// Thrown if the <see cref="HttpResponseMessage"/> indicates an unsuccessful status code
+		/// </exception>
+		public static async Task<Stream> GetStreamIfSuccessfulOrThrowAsync(HttpResponseMessage message, IExceptionReconstructor reconstructor, params HttpStatusCode[] validCodes)
+		{
+			await ThrowIfNotSuccessfulAsync(message, reconstructor, validCodes).ConfigureAwait(false);
+
+			return await message.Content.ReadAsStreamAsync().ConfigureAwait(false);
 		}
 	}
 }

--- a/CaptainPav.WebApiProxy/IHttpResponseMessageReader.cs
+++ b/CaptainPav.WebApiProxy/IHttpResponseMessageReader.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -25,8 +26,26 @@ namespace CaptainPav.WebApiProxy
 		/// otherwise, an exception is thrown.
 		/// </returns>
 		/// <exception cref="UnexpectedStatusCodeException">
-		/// Throw if the <see cref="HttpResponseMessage"/> indicates an unsuccessful status code
+		/// Thrown if the <see cref="HttpResponseMessage"/> indicates an unsuccessful status code
 		/// </exception>
 		Task<string> ReadMessageIfSuccessfulOrThrowAsync(HttpResponseMessage message, params HttpStatusCode[] validCodes);
-	}
+
+		Task<Stream> GetStreamIfSuccessfulOrThrowAsync(HttpResponseMessage message, params HttpStatusCode[] validCodes);
+
+		/// <summary>
+		/// Throws an exception if the response message indicates
+		/// an unsuccessful result
+		/// </summary>
+		/// <param name="message">
+		/// The <see cref="HttpResponseMessage"/> to check for failure
+		/// </param>
+        /// <param name="validCodes">
+        /// The set of <see cref="HttpStatusCode"/>s which represent a successful call
+        /// </param>
+        /// <remarks>
+        /// This method will try to reconstruct the original exception sent in the
+        /// body of the response
+        /// </remarks>
+		Task ThrowIfNotSuccessfulAsync(HttpResponseMessage message, params HttpStatusCode[] validCodes);
+    }
 }

--- a/CaptainPav.WebApiProxy/JsonHttpResponseMessageParser.cs
+++ b/CaptainPav.WebApiProxy/JsonHttpResponseMessageParser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -12,6 +13,8 @@ namespace CaptainPav.WebApiProxy
 	/// </summary>
 	public class JsonHttpResponseMessageParser : IHttpResponseMessageParser
 	{
+		private static JsonSerializer StreamDeserializer { get; } = new JsonSerializer();
+
 		/// <summary>
 		/// Gets the reader which consumes the <see cref="HttpResponseMessage"/> and returns
 		/// the content body as string data
@@ -27,25 +30,30 @@ namespace CaptainPav.WebApiProxy
 		/// </param>
 		public JsonHttpResponseMessageParser(IHttpResponseMessageReader reader)
 		{
-			if (null == reader)
-			{
-				throw new ArgumentNullException(nameof(reader));
-			}
-
-			this.MessageReader = reader;
+            this.MessageReader = reader ?? throw new ArgumentNullException(nameof(reader));
 		}
 
 		/// <inheritdoc />
 		public Task ParseAsync(HttpResponseMessage message, params HttpStatusCode[] validCodes)
 		{
-			return this.MessageReader.ReadMessageIfSuccessfulOrThrowAsync(message, validCodes);
+			return this.MessageReader.ThrowIfNotSuccessfulAsync(message, validCodes);
 		}
 
 		/// <inheritdoc />
 		public async Task<TResponse> ParseAsync<TResponse>(HttpResponseMessage message, string jsonTokenSelector = null, params HttpStatusCode[] validCodes)
 		{
-			string bodyContent = await this.MessageReader.ReadMessageIfSuccessfulOrThrowAsync(message, validCodes).ConfigureAwait(false);
-			return InnerParse<TResponse>(bodyContent, jsonTokenSelector);
+            if (String.IsNullOrWhiteSpace(jsonTokenSelector))
+            {
+                using (var stream = await this.MessageReader.GetStreamIfSuccessfulOrThrowAsync(message, validCodes).ConfigureAwait(false))
+                using (var reader = new StreamReader(stream))
+                using (var json = new JsonTextReader(reader))
+                {
+                    return StreamDeserializer.Deserialize<TResponse>(json);
+                }
+            }
+
+            string bodyContent = await this.MessageReader.ReadMessageIfSuccessfulOrThrowAsync(message, validCodes).ConfigureAwait(false);
+            return InnerParse<TResponse>(bodyContent, jsonTokenSelector);
 		}
 
 		/// <summary>


### PR DESCRIPTION
optimize parser to read stream instead of buffer json string when json token selector is not specified.  do not parse response body just to determine if the response was successful.